### PR TITLE
Update nginx config to set origin and hide allow origin from backends

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -7,7 +7,7 @@ server {
 
     location / {
          if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Origin' '$http_origin';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
             #
             # Custom headers and headers various browsers *should* be OK with but aren't
@@ -18,21 +18,25 @@ server {
             #
             add_header 'Access-Control-Max-Age' 1728000;
             add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Content-Length' 0;
             return 204;
          }
          if ($request_method = 'POST') {
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Origin' '$http_origin';
+            add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
             add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
             add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
          }
          if ($request_method = 'GET') {
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Origin' '$http_origin';
+            add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
             add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
             add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
          }
+         proxy_hide_header 'Access-Control-Allow-Origin';
          proxy_pass ___TARGET___;
     }
 

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,24 @@
-# nginx-cors-plus
+# nginx-cors-proxy
 
 A simple nginx proxy that you can put in front of any domain to enable CORS.
-Handles the preflight requests that can occur when trying to use `application/json` 
+Handles the preflight requests that can occur when trying to use `application/json`
 as the request content-type.
- 
-** Docker Run: **
 
-```bash
-docker run -p 8080:80 -e TARGET=example.com shakyshane/nginx-cors-plus
+## Build the Container
+
+```
+docker build -t nginx-cors-proxy .
 ```
 
-** Docker Compose: **
+## Run the Container
+
+### Docker Run
+
+```bash
+docker run -it --rm -p 80:80 -e TARGET=http://example.com nginx-cors-proxy
+```
+
+### Docker Compose
 
 ```yaml
 version: '2'


### PR DESCRIPTION
Hi,

Thanks for the repo! I've just changed the origin from wildcard to $http_origin so it matches whatever comes through and allows setting 'Access-Control-Allow-Credentials' which doesn't work with wildcard origins. Also, I hide the origin header sent by the backend so it doesn't clash with what's happening here.