### PR TITLE
Fixing behavior for all HTTP statuses

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -21,18 +21,10 @@ server {
             add_header 'Content-Length' 0;
             return 204;
          }
-         if ($request_method = 'POST') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-            add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-         }
-         if ($request_method = 'GET') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-            add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-         }
+         add_header 'Access-Control-Allow-Origin' '*';
+         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+         add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+         add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
          proxy_pass ___TARGET___;
     }
 

--- a/default.conf
+++ b/default.conf
@@ -6,7 +6,7 @@ server {
     #access_log  /var/log/nginx/log/host.access.log  main;
 
     location / {
-         if ($request_method = 'OPTIONS') {
+        if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
             #
@@ -20,12 +20,12 @@ server {
             add_header 'Content-Type' 'text/plain charset=UTF-8' always;
             add_header 'Content-Length' 0 always;
             return 204;
-         }
-         add_header 'Access-Control-Allow-Origin' '*' always;
-         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-         add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
-         add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
-         proxy_pass ___TARGET___;
+        }
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
+        add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
+        proxy_pass ___TARGET___;
     }
 
     #error_page  404              /404.html;

--- a/default.conf
+++ b/default.conf
@@ -8,7 +8,7 @@ server {
     location / {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             #
             # Custom headers and headers various browsers *should* be OK with but aren't
             #
@@ -22,7 +22,7 @@ server {
             return 204;
         }
         add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
         add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
         add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
         proxy_pass ___TARGET___;

--- a/default.conf
+++ b/default.conf
@@ -2,6 +2,8 @@ server {
     listen       80;
     server_name  localhost;
 
+    client_max_body_size 0;
+
     #charset koi8-r;
     #access_log  /var/log/nginx/log/host.access.log  main;
 

--- a/default.conf
+++ b/default.conf
@@ -7,24 +7,24 @@ server {
 
     location / {
          if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
             #
             # Custom headers and headers various browsers *should* be OK with but aren't
             #
-            add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+            add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
             #
             # Tell client that this pre-flight info is valid for 20 days
             #
-            add_header 'Access-Control-Max-Age' 1728000;
-            add_header 'Content-Type' 'text/plain charset=UTF-8';
-            add_header 'Content-Length' 0;
+            add_header 'Access-Control-Max-Age' 1728000 always;
+            add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+            add_header 'Content-Length' 0 always;
             return 204;
          }
-         add_header 'Access-Control-Allow-Origin' '*';
-         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-         add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-         add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+         add_header 'Access-Control-Allow-Origin' '*' always;
+         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+         add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
+         add_header 'Access-Control-Expose-Headers' 'Authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
          proxy_pass ___TARGET___;
     }
 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ as the request content-type.
 ** Docker Run: **
 
 ```bash
-docker run -p 8080:80 -e TARGET=example.com shakyshane/nginx-cors-plus
+docker run -p 8080:80 -e TARGET=example.com caousn/nginx-cors-plus
 ```
 
 ** Docker Compose: **
@@ -16,7 +16,7 @@ docker run -p 8080:80 -e TARGET=example.com shakyshane/nginx-cors-plus
 version: '2'
 services:
   nginx:
-    image: shakyshane/nginx-cors-plus
+    image: caousn/nginx-cors-plus
     ports:
       - 8090:80
     environment:


### PR DESCRIPTION
Fix for Issue #4 

[The always parameter forces nginx to add_headers on all statuses](http://nginx.org/en/docs/http/ngx_http_headers_module.html)

['If' has unexpected behavior](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/)

Example: https://cloud.docker.com/u/caousn/repository/docker/caousn/nginx-cors-plus